### PR TITLE
Startify: don't remove hl of StartifyFile

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -239,10 +239,6 @@ call s:hi('gitcommitSummary', 'fg', '')
 call s:hi('gitcommitOverflow', 'markup', '')
 " }}}
 
-" Startify:" {{{
-call s:hi('StartifyFile', 'fg', '')
-" }}}
-
 " Vim:" {{{
 call s:hi('vimUserFunc', 'func', '')
 hi! link vimVar NONE


### PR DESCRIPTION
I'm not sure this should be highlighted as fg,
the default is identifier, which I think is great.