### PR TITLE
Extended color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ set termguicolors       " enable true colors support
 
 set background=light    " for light version of theme
 set background=dark     " for either mirage or dark version.
+" NOTE: `background` controls `g:ayucolor`, but `g:ayucolor` doesn't control `background`
 
 let g:ayucolor="mirage" " for mirage version of theme
 let g:ayucolor="dark"   " for dark version of theme
@@ -63,7 +64,7 @@ And here is a list of other supported syntax groups:
 ```VimL
 let g:ayu_italic_comment = 1 " defaults to 0.
 let g:ayu_sign_contrast = 1 " defaults to 0. If set to 1, SignColumn and FoldColumn will have a higher contrast instead of using the Normal background
-let g:ayu_extended_palette = 1 " defaults to 0. If set, enables extended palette. Adds more colors to some highlights ("function" keyword, loops, conditionals, imports)
+let g:ayu_extended_palette = 1 " defaults to 0. If set to 1, enables extended palette. Adds more colors to some highlights (function keyword, loops, conditionals, imports)
 ```
 
 # nvim-ts-rainbow Colors

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![Ayu - Banner](https://user-images.githubusercontent.com/10234894/156601082-7c748734-2aa8-467a-8160-285815af3720.png)
+
+# Ayu vim (unofficial fork)
+
+From left to right `let ayucolor` = `light`, `mirage`, `dark`
 ![Ayu - Demonstration](https://user-images.githubusercontent.com/10234894/156596711-3a48210a-112d-4dc5-98ff-b1576be7ca28.png)
 
 With `let g:ayu_extended_palette = 1`:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 ![ayu-vim](http://i.imgur.com/7vnF4Na.png)
 
-# Warning
-
-`ayu` is still in development and a lot of things need to be covered. Theme works only if VIM supports `termguicolors` option. This is true for [Neovim](https://neovim.io) and VIM from 7.4.1799.
-
 # Installation
+
+`ayu` only works if VIM supports `termguicolors` option. This is true for [Neovim](https://neovim.io) and VIM from 7.4.1799.
 
 ```VimL
 Plug 'Luxed/ayu-vim'    " or other package manager
@@ -57,17 +55,18 @@ And here is a list of other supported syntax groups:
 ```VimL
 let g:ayu_italic_comment = 1 " defaults to 0.
 let g:ayu_sign_contrast = 1 " defaults to 0. If set to 1, SignColumn and FoldColumn will have a higher contrast instead of using the Normal background
+let g:ayu_extended_palette = 1 " defaults to 0. If set, enables extended palette. Adds more colors to some highlights ("function" keyword, loops, conditionals, imports)
 ```
 
 # nvim-ts-rainbow Colors
 
-In your Tree-Sitter configuration add the following:
+In your Tree-Sitter configuration add the following (in lua):
 
 ```lua
 require('nvim-treesitter.configs').setup{
   rainbow = {
     enable = true,
-    colors = require('ayu').rainbow_colors
+    colors = require('ayu').rainbow_colors()
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-![ayu-vim](http://i.imgur.com/7vnF4Na.png)
+![Ayu - Demonstration](https://user-images.githubusercontent.com/10234894/156596711-3a48210a-112d-4dc5-98ff-b1576be7ca28.png)
+
+With `let g:ayu_extended_palette = 1`:
+![Ayu - Extended color palette](https://user-images.githubusercontent.com/10234894/156596727-eb78d8c0-6aa5-42c4-8e25-64f9388dc765.png)
 
 # Installation
 

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -1,4 +1,4 @@
-let s:experimental_colors = get(g:, 'ayu_experimental_colors', 0)
+let s:extended_palette = get(g:, 'ayu_extended_palette', 0)
 
 " Official Palette:" {{{
 let g:ayu#palette = {}
@@ -53,7 +53,7 @@ let g:ayu#palette.fg_idle  = {'light': "#828C99", 'mirage': "#607080", 'dark': "
 let g:ayu#palette.warning  = {'light': "#FA8D3E", 'mirage': "#FFA759", 'dark': "#FF8F40"}
 let g:ayu#palette.float_bg = {'light': "#d8d8d8", 'mirage': "#2D323F", 'dark': "#161e26"}
 
-if s:experimental_colors
+if s:extended_palette
     let g:ayu#palette.keyword_func = {'light': "#3EABFA", 'mirage': "#80AAFF", 'dark': "#40B0FF"}
     let g:ayu#palette.repeat       = {'light': "#FA3E4D", 'mirage': "#FF595E", 'dark': "#FF4051"}
     let g:ayu#palette.conditional  = {'light': "#F9700C", 'mirage': "#FF8214", 'dark': "#FF710D"}

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -52,10 +52,17 @@ let g:ayu#palette.vcs_removed        = {'light': "#F27983",  'mirage': "#F27983"
 let g:ayu#palette.fg_idle = {'light': "#828C99",  'mirage': "#607080",  'dark': "#3E4B59"}
 let g:ayu#palette.warning = {'light': "#FA8D3E",  'mirage': "#FFA759",  'dark': "#FF8F40"}
 
-let g:ayu#palette.keyword_func = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#80AAFF" : "#FFA759",  'dark': "#FF8F40"}
-let g:ayu#palette.repeat       = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#FF595E" : "#FFA759",  'dark': "#FF8F40"}
-let g:ayu#palette.conditional  = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#FF8214" : "#FFA759",  'dark': "#FF8F40"}
-let g:ayu#palette.import       = {'light': "#FF9940", 'mirage': s:experimental_colors ? "#FFBB33" : "#FFCC66", 'dark': "#E6B450"}
+if s:experimental_colors
+    let g:ayu#palette.keyword_func = {'light': "#3EABFA", 'mirage': "#80AAFF", 'dark': "#40B0FF"}
+    let g:ayu#palette.repeat       = {'light': "#FA3E4D", 'mirage': "#FF595E", 'dark': "#FF4051"}
+    let g:ayu#palette.conditional  = {'light': "#F9700C", 'mirage': "#FF8214", 'dark': "#FF710D"}
+    let g:ayu#palette.import       = {'light': "#FF7E0D", 'mirage': "#FFBB33", 'dark': "#E0A123"}
+else
+    let g:ayu#palette.keyword_func = g:ayu#palette.keyword
+    let g:ayu#palette.repeat       = g:ayu#palette.keyword
+    let g:ayu#palette.conditional  = g:ayu#palette.keyword
+    let g:ayu#palette.import       = g:ayu#palette.accent
+endif
 
 " }}}
 

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -1,3 +1,5 @@
+let s:experimental_colors = get(g:, 'ayu_experimental_colors', 0)
+
 " Official Palette:" {{{
 let g:ayu#palette = {}
 
@@ -49,6 +51,10 @@ let g:ayu#palette.vcs_removed        = {'light': "#F27983",  'mirage': "#F27983"
 
 let g:ayu#palette.fg_idle = {'light': "#828C99",  'mirage': "#607080",  'dark': "#3E4B59"}
 let g:ayu#palette.warning = {'light': "#FA8D3E",  'mirage': "#FFA759",  'dark': "#FF8F40"}
+
+let g:ayu#palette.keyword_func = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#80AAFF" : "#FFA759",  'dark': "#FF8F40"}
+let g:ayu#palette.repeat       = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#FF595E" : "#FFA759",  'dark': "#FF8F40"}
+let g:ayu#palette.conditional  = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#FF8214" : "#FFA759",  'dark': "#FF8F40"}
 
 " }}}
 

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -55,6 +55,7 @@ let g:ayu#palette.warning = {'light': "#FA8D3E",  'mirage': "#FFA759",  'dark': 
 let g:ayu#palette.keyword_func = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#80AAFF" : "#FFA759",  'dark': "#FF8F40"}
 let g:ayu#palette.repeat       = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#FF595E" : "#FFA759",  'dark': "#FF8F40"}
 let g:ayu#palette.conditional  = {'light': "#FA8D3E", 'mirage': s:experimental_colors ? "#FF8214" : "#FFA759",  'dark': "#FF8F40"}
+let g:ayu#palette.import       = {'light': "#FF9940", 'mirage': s:experimental_colors ? "#FFBB33" : "#FFCC66", 'dark': "#E6B450"}
 
 " }}}
 

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -58,6 +58,10 @@ call ayu#hi('Title', 'keyword', '')
 call ayu#hi('Visual', '', 'selection_inactive')
 call ayu#hi('WarningMsg', 'warning', '')
 
+" Experimental
+call ayu#hi('Conditional', 'conditional', '')
+call ayu#hi('Repeat', 'repeat', '')
+
 "}}}
 
 " Generic Syntax Highlighting: (see :help group-name)"{{{
@@ -95,6 +99,9 @@ call ayu#hi('qfLineNr', 'keyword', '')
 
 call ayu#hi('Conceal', 'comment', '')
 call ayu#hi('CursorLineConceal', 'guide_normal', 'line')
+
+" Experimental
+call ayu#hi('PreCondit', 'conditional', '')
 
 "}}}
 
@@ -236,6 +243,13 @@ call ayu#hi('typescriptGlobalMethod', 'func', '')
 call ayu#hi('typescriptFunctionMethod', 'func', '')
 call ayu#hi('typescriptBOMLocationMethod', 'func', '')
 
+" Experimental
+call ayu#hi('typescriptFuncKeyword', 'keyword_func', '')
+call ayu#hi('typescriptConditional', 'conditional', '')
+call ayu#hi('typescriptCase', 'conditional', '')
+call ayu#hi('typescriptRepeat', 'repeat', '')
+call ayu#hi('typescriptBranch', 'repeat', '')
+
 " }}}
 
 " Javascript:" {{{
@@ -254,6 +268,9 @@ call ayu#hi('jsObjectKey', 'tag', '')
 call ayu#hi('jsObjectProp', 'tag', '')
 
 call ayu#hi('jsRegexpString', 'regexp', '')
+
+" Experimental
+call ayu#hi('jsFunction', 'keyword_func', '')
 
 " }}}
 
@@ -274,6 +291,11 @@ call ayu#hi('TSConstBuiltin', 'constant', '')
 call ayu#hi('TSStringRegex', 'regexp', '')
 
 call ayu#hi('TSFuncMacro', 'func', '')
+
+" Experimental
+call ayu#hi('TSKeywordFunction', 'keyword_func', '')
+call ayu#hi('TSRepeat', 'repeat', '')
+call ayu#hi('TSConditional', 'conditional', '')
 
 " }}}
 

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -198,7 +198,7 @@ call ayu#hi('LspDiagnosticsSignInformation', 'fg', s:sign_bg())
 " YATS:" {{{
 
 call ayu#hi('typescriptDecorator', 'markup', '')
-call ayu#hi('typescriptImport', 'accent', '')
+call ayu#hi('typescriptImport', 'import', '')
 call ayu#hi('typescriptExport', 'accent', '')
 call ayu#hi('typescriptIdentifier', 'tag', '', 'italic')
 call ayu#hi('typescriptAssign', 'operator', '')
@@ -276,7 +276,7 @@ call ayu#hi('jsFunction', 'keyword_func', '')
 
 " TreeSitter:" {{{
 
-call ayu#hi('TSInclude', 'accent', '')
+call ayu#hi('TSInclude', 'import', '')
 
 call ayu#hi('TSParameter', 'special', '')
 

--- a/lua/ayu.lua
+++ b/lua/ayu.lua
@@ -1,8 +1,28 @@
 return {
-  rainbow_colors = {
-    '#FFF9EC',
-    '#FFE6B3',
-    '#FFCA5A',
-    '#FFAE00',
-  }
+  rainbow_colors = function()
+    local style = vim.fn['ayu#get_style']()
+    if style == 'light' then
+      return {
+        '#F0D5AF',
+        '#E6BA7E',
+        '#B89565',
+        '#8A704C'
+      }
+    elseif style == 'mirage' then
+      return {
+        '#FFF9EC',
+        '#FFE6B3',
+        '#FFCA5A',
+        '#FFAE00',
+      }
+    elseif style == 'dark' then
+      return {
+        '#F0D2A8',
+        '#E6B673',
+        '#B8915C',
+        '#8A7D45',
+      }
+    end
+    return nil
+  end
 }


### PR DESCRIPTION
This PR is to finally merge the work I have started in the "experimental colors" branch.
I felt like the theme was missing some important highlight groups.
For example, I wanted my conditions to be highlighted different to be able to more easily find them. I also wanted my loops to pop out as they are a critical point of any language.
Here's a few screenshots:
![image](https://user-images.githubusercontent.com/10234894/122940438-776f0980-d342-11eb-81ac-f03090d536de.png)
![image](https://user-images.githubusercontent.com/10234894/122940643-a5544e00-d342-11eb-86f6-0609683a182f.png)

### Here's a list of changes:
- Added `conditional` palette. Darker "keyword".
- Added `repeat` palette. Analogous "keyword".
- Added `keyword_func` palette. Complementary "keyword".
- Added `import` palette. Darker "accent".

Changes have been done to the 3 color palettes available (light, mirage and dark).

### Here's how to test it:
- use this branch in your config (it should always be up to date with master).
- set the `g:ayu_experimental_colors` variable to `1` or `true` in your config _before_ doing `colorscheme ayu`.

Currently, this setting enables everything at once.
As always, feedback is welcome!