### PR TITLE
add html tag color

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -323,6 +323,32 @@ call ayu#hi('xmlEqual', 'operator', '')
 
 " }}}
 
+" HTML:" {{{
+
+hi def htmlBold                term=bold cterm=bold gui=bold
+hi def htmlBoldUnderline       term=bold,underline cterm=bold,underline gui=bold,underline
+hi def htmlBoldItalic          term=bold,italic cterm=bold,italic gui=bold,italic
+hi def htmlBoldUnderlineItalic term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
+hi def htmlUnderline           term=underline cterm=underline gui=underline
+hi def htmlUnderlineItalic     term=italic,underline cterm=italic,underline gui=italic,underline
+hi def htmlItalic              term=italic cterm=italic gui=italic
+
+" open - close tag
+call ayu#hi('htmlTag', 'tag', '')
+call ayu#hi('htmlTagName', 'entity', '')
+call ayu#hi('htmlTagN', 'entity', '')
+call ayu#hi('htmlEndTag', 'tag', '')
+
+" attribute
+call ayu#hi('htmlArg', 'operator', '')
+
+" text inner tag
+hi link htmlH1 Normal
+hi link htmlTitle Normal
+
+" }}}
+
+
 " INI:" {{{
 call ayu#hi('dosiniHeader', 'keyword', '')
 " }}}

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -325,14 +325,6 @@ call ayu#hi('xmlEqual', 'operator', '')
 
 " HTML:" {{{
 
-hi def htmlBold                term=bold cterm=bold gui=bold
-hi def htmlBoldUnderline       term=bold,underline cterm=bold,underline gui=bold,underline
-hi def htmlBoldItalic          term=bold,italic cterm=bold,italic gui=bold,italic
-hi def htmlBoldUnderlineItalic term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
-hi def htmlUnderline           term=underline cterm=underline gui=underline
-hi def htmlUnderlineItalic     term=italic,underline cterm=italic,underline gui=italic,underline
-hi def htmlItalic              term=italic cterm=italic gui=italic
-
 " open - close tag
 call ayu#hi('htmlTag', 'tag', '')
 call ayu#hi('htmlTagName', 'entity', '')
@@ -343,6 +335,7 @@ call ayu#hi('htmlEndTag', 'tag', '')
 call ayu#hi('htmlArg', 'operator', '')
 
 " text inner tag
+hi link htmlLink Normal
 hi link htmlH1 Normal
 hi link htmlTitle Normal
 


### PR DESCRIPTION
it still doesn't support some html5 tags like < svg > and so on, so I still need to install https://github.com/othree/html5.vim


![Screenshot from 2021-09-17 14-38-19](https://user-images.githubusercontent.com/69284713/133745464-c1388192-a997-423a-a4e7-7be9e7304bbf.png)
