### PR TITLE
Add a "generator" that generates the autoload ayu.vim file containing all of the colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Here is a list of plugins which have been customized to work better with this th
 - [haskell-vim](https://github.com/neovimhaskell/haskell-vim). Haskell syntax highlighting.
 - [nvim-compe](https://github.com/hrsh7th/nvim-compe). Neovim completion plugin.
 - [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
+- [nvim-cmp](https://github.com/hrsh7th/nvim-cmp). Neovim completion plugin, successor to compe.
+- [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim). Indentation guides.
 
 And here is a list of other supported syntax groups:
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 # Ayu vim (unofficial fork)
 
 From left to right `let ayucolor` = `light`, `mirage`, `dark`
-![Ayu - Demonstration](https://user-images.githubusercontent.com/10234894/156596711-3a48210a-112d-4dc5-98ff-b1576be7ca28.png)
+![Ayu - Demonstration](https://user-images.githubusercontent.com/10234894/156945507-ab1ef129-df1d-4633-ab1b-c89868ff7e73.png)
 
 With `let g:ayu_extended_palette = 1`:
-![Ayu - Extended color palette](https://user-images.githubusercontent.com/10234894/156596727-eb78d8c0-6aa5-42c4-8e25-64f9388dc765.png)
+![Ayu - Extended color palette](https://user-images.githubusercontent.com/10234894/156945599-85027644-b5ac-47d1-a70e-5896b8618b4f.png)
 
 # Installation
 

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -1,71 +1,58 @@
+" File automatically generated on 'Sun Mar 06 2022 14:02:49 GMT-0500 (Eastern Standard Time)'
+
+let g:ayu#palette = {}
+let g:ayu#palette['syntax_tag']                    = {'light': '#55b4d4', 'mirage': '#5ccfe6', 'dark': '#39bae6'}
+let g:ayu#palette['syntax_func']                   = {'light': '#f2ae49', 'mirage': '#ffd173', 'dark': '#ffb454'}
+let g:ayu#palette['syntax_entity']                 = {'light': '#399ee6', 'mirage': '#73d0ff', 'dark': '#59c2ff'}
+let g:ayu#palette['syntax_string']                 = {'light': '#86b300', 'mirage': '#d5ff80', 'dark': '#aad94c'}
+let g:ayu#palette['syntax_regexp']                 = {'light': '#4cbf99', 'mirage': '#95e6cb', 'dark': '#95e6cb'}
+let g:ayu#palette['syntax_markup']                 = {'light': '#f07171', 'mirage': '#f28779', 'dark': '#f07178'}
+let g:ayu#palette['syntax_keyword']                = {'light': '#fa8d3e', 'mirage': '#ffad66', 'dark': '#ff8f40'}
+let g:ayu#palette['syntax_special']                = {'light': '#e6ba7e', 'mirage': '#ffdfb3', 'dark': '#e6b673'}
+let g:ayu#palette['syntax_comment']                = {'light': '#adafb2', 'mirage': '#6e7c8e', 'dark': '#646b73'}
+let g:ayu#palette['syntax_constant']               = {'light': '#a37acc', 'mirage': '#dfbfff', 'dark': '#d2a6ff'}
+let g:ayu#palette['syntax_operator']               = {'light': '#ed9366', 'mirage': '#f29e74', 'dark': '#f29668'}
+let g:ayu#palette['vcs_added']                     = {'light': '#6cbf43', 'mirage': '#87d96c', 'dark': '#7fd962'}
+let g:ayu#palette['vcs_modified']                  = {'light': '#478acc', 'mirage': '#80bfff', 'dark': '#73b8ff'}
+let g:ayu#palette['vcs_removed']                   = {'light': '#ff7383', 'mirage': '#f27983', 'dark': '#f26d78'}
+let g:ayu#palette['editor_fg']                     = {'light': '#5c6166', 'mirage': '#cccac2', 'dark': '#bfbdb6'}
+let g:ayu#palette['editor_bg']                     = {'light': '#fcfcfc', 'mirage': '#242936', 'dark': '#0d1017'}
+let g:ayu#palette['editor_line']                   = {'light': '#f1f1f2', 'mirage': '#1a1f29', 'dark': '#131721'}
+let g:ayu#palette['editor_selection_active']       = {'light': '#d7e4f6', 'mirage': '#2b4768', 'dark': '#1c3b5d'}
+let g:ayu#palette['editor_selection_inactive']     = {'light': '#ebf1f9', 'mirage': '#283850', 'dark': '#142335'}
+let g:ayu#palette['editor_findMatch_active']       = {'light': '#ecdcfd', 'mirage': '#695380', 'dark': '#6c5980'}
+let g:ayu#palette['editor_findMatch_inactive']     = {'light': '#b266fe', 'mirage': '#403a54', 'dark': '#332d41'}
+let g:ayu#palette['editor_gutter_active']          = {'light': '#a1a6ad', 'mirage': '#767c85', 'dark': '#626976'}
+let g:ayu#palette['editor_gutter_normal']          = {'light': '#ced1d4', 'mirage': '#4d535e', 'dark': '#464b56'}
+let g:ayu#palette['editor_indentGuide_active']     = {'light': '#d4d7d9', 'mirage': '#484d59', 'dark': '#3d424c'}
+let g:ayu#palette['editor_indentGuide_normal']     = {'light': '#e7e9ea', 'mirage': '#363c48', 'dark': '#20242c'}
+let g:ayu#palette['ui_fg']                         = {'light': '#8a9199', 'mirage': '#707a8c', 'dark': '#565b66'}
+let g:ayu#palette['ui_bg']                         = {'light': '#f8f9fa', 'mirage': '#1f2430', 'dark': '#0b0e14'}
+let g:ayu#palette['ui_line']                       = {'light': '#e7eaed', 'mirage': '#171b24', 'dark': '#11151c'}
+let g:ayu#palette['ui_selection_active']           = {'light': '#e5e9ed', 'mirage': '#293040', 'dark': '#1a1f29'}
+let g:ayu#palette['ui_selection_normal']           = {'light': '#e7eaed', 'mirage': '#282e3b', 'dark': '#171c24'}
+let g:ayu#palette['ui_panel_bg']                   = {'light': '#f3f4f5', 'mirage': '#1c212b', 'dark': '#0f131a'}
+let g:ayu#palette['ui_panel_shadow']               = {'light': '#d3d4d4', 'mirage': '#161a22', 'dark': '#06070a'}
+let g:ayu#palette['common_accent']                 = {'light': '#ffaa33', 'mirage': '#ffcc66', 'dark': '#e6b450'}
+let g:ayu#palette['common_error']                  = {'light': '#e65050', 'mirage': '#ff6666', 'dark': '#d95757'}
+
 let s:extended_palette = get(g:, 'ayu_extended_palette', 0)
 
-" Official Palette:" {{{
-let g:ayu#palette = {}
-
-" common
-let g:ayu#palette.accent             = {'light': "#FF9940",  'mirage': "#FFCC66",  'dark': "#E6B450"}
-let g:ayu#palette.bg                 = {'light': "#FAFAFA",  'mirage': "#1F2430",  'dark': "#0A0E14"}
-let g:ayu#palette.fg                 = {'light': "#575F66",  'mirage': "#CBCCC6",  'dark': "#B3B1AD"}
-let g:ayu#palette.ui                 = {'light': "#8A9199",  'mirage': "#707A8C",  'dark': "#4D5566"}
-
-" syntax
-let g:ayu#palette.tag                = {'light': "#55B4D4",  'mirage': "#5CCFE6",  'dark': "#39BAE6"}
-let g:ayu#palette.func               = {'light': "#F2AE49",  'mirage': "#FFD580",  'dark': "#FFB454"}
-let g:ayu#palette.entity             = {'light': "#399EE6",  'mirage': "#73D0FF",  'dark': "#59C2FF"}
-let g:ayu#palette.string             = {'light': "#86B300",  'mirage': "#BAE67E",  'dark': "#C2D94C"}
-let g:ayu#palette.regexp             = {'light': "#4CBF99",  'mirage': "#95E6CB",  'dark': "#95E6CB"}
-let g:ayu#palette.markup             = {'light': "#F07171",  'mirage': "#F28779",  'dark': "#F07178"}
-let g:ayu#palette.keyword            = {'light': "#FA8D3E",  'mirage': "#FFA759",  'dark': "#FF8F40"}
-let g:ayu#palette.special            = {'light': "#E6BA7E",  'mirage': "#FFE6B3",  'dark': "#E6B673"}
-let g:ayu#palette.comment            = {'light': "#ABB0B6",  'mirage': "#5C6773",  'dark': "#626A73"}
-let g:ayu#palette.constant           = {'light': "#A37ACC",  'mirage': "#D4BFFF",  'dark': "#FFEE99"}
-let g:ayu#palette.operator           = {'light': "#ED9366",  'mirage': "#F29E74",  'dark': "#F29668"}
-let g:ayu#palette.error              = {'light': "#F51818",  'mirage': "#FF3333",  'dark': "#FF3333"}
-
-" ui
-" some of these colors should have transparency. Since this is not possible,
-" they only 'emulate' their colors as if they were shown on the regular
-" backaground color
-let g:ayu#palette.line               = {'light': "#EFF0F1",  'mirage': "#191E2A",  'dark': "#00010A"}
-let g:ayu#palette.panel_bg           = {'light': "#FFFFFF",  'mirage': "#232834",  'dark': "#0D1016"}
-let g:ayu#palette.panel_shadow       = {'light': "#CCCED0",  'mirage': "#141925",  'dark': "#00010A"}
-let g:ayu#palette.panel_border       = {'light': "#F0F0F0",  'mirage': "#101521",  'dark': "#000000"}
-let g:ayu#palette.gutter_normal      = {'light': "#CDD0D3",  'mirage': "#404755",  'dark': "#323945"}
-let g:ayu#palette.gutter_active      = {'light': "#A0A6AC",  'mirage': "#5F687A",  'dark': "#464D5E"}
-let g:ayu#palette.selection_bg       = {'light': "#D1E4F4",  'mirage': "#33415E",  'dark': "#273747"}
-let g:ayu#palette.selection_inactive = {'light': "#E7E8E9",  'mirage': "#323A4C",  'dark': "#1B2733"}
-let g:ayu#palette.selection_border   = {'light': "#E1E1E2",  'mirage': "#232A4C",  'dark': "#304357"}
-let g:ayu#palette.guide_active       = {'light': "#D3D5D8",  'mirage': "#576070",  'dark': "#393F4D"}
-let g:ayu#palette.guide_normal       = {'light': "#E6E7E9",  'mirage': "#383E4C",  'dark': "#242A35"}
-
-" vcs
-let g:ayu#palette.vcs_added          = {'light': "#99BF4D",  'mirage': "#A6CC70",  'dark': "#91B362"}
-let g:ayu#palette.vcs_modified       = {'light': "#709ECC",  'mirage': "#77A8D9",  'dark': "#6994BF"}
-let g:ayu#palette.vcs_removed        = {'light': "#F27983",  'mirage': "#F27983",  'dark': "#D96C75"}
-
-" TODO: Add 16 color palette for convenience
-" }}}
-
-" Extended Color Palette:" {{{
-
-let g:ayu#palette.fg_idle  = {'light': "#828C99", 'mirage': "#607080", 'dark': "#3E4B59"}
-let g:ayu#palette.warning  = {'light': "#FA8D3E", 'mirage': "#FFA759", 'dark': "#FF8F40"}
-let g:ayu#palette.float_bg = {'light': "#d8d8d8", 'mirage': "#2D323F", 'dark': "#161e26"}
+let g:ayu#palette['extended_fg_idle']          = {'light': '#828C99', 'mirage': '#607080', 'dark': '#3E4B59'}
+let g:ayu#palette['extended_warning']          = {'light': '#FA8D3E', 'mirage': '#FFA759', 'dark': '#FF8F40'}
+let g:ayu#palette['extended_float_bg']         = {'light': '#D8D8D8', 'mirage': '#2D323F', 'dark': '#161e26'}
 
 if s:extended_palette
-    let g:ayu#palette.keyword_func = {'light': "#3EABFA", 'mirage': "#80AAFF", 'dark': "#40B0FF"}
-    let g:ayu#palette.repeat       = {'light': "#FA3E4D", 'mirage': "#FF595E", 'dark': "#FF4051"}
-    let g:ayu#palette.conditional  = {'light': "#F9700C", 'mirage': "#FF8214", 'dark': "#FF710D"}
-    let g:ayu#palette.import       = {'light': "#FF7E0D", 'mirage': "#FFBB33", 'dark': "#E0A123"}
+    let g:ayu#palette['extended_keyword_func'] = {'light': '#3EABFA', 'mirage': '#80AAFF', 'dark': '#40B0FF'}
+    let g:ayu#palette['extended_repeat']       = {'light': '#FA3E4D', 'mirage': '#FF595E', 'dark': '#FF4051'}
+    let g:ayu#palette['extended_conditional']  = {'light': '#F9700C', 'mirage': '#FF8214', 'dark': '#FF710D'}
+    let g:ayu#palette['extended_import']       = {'light': '#FF7E0D', 'mirage': '#FFBB33', 'dark': '#E0A123'}
 else
-    let g:ayu#palette.keyword_func = g:ayu#palette.keyword
-    let g:ayu#palette.repeat       = g:ayu#palette.keyword
-    let g:ayu#palette.conditional  = g:ayu#palette.keyword
-    let g:ayu#palette.import       = g:ayu#palette.accent
+    let g:ayu#palette['extended_keyword_func'] = g:ayu#palette['keyword']
+    let g:ayu#palette['extended_repeat']       = g:ayu#palette['keyword']
+    let g:ayu#palette['extended_conditional']  = g:ayu#palette['keyword']
+    let g:ayu#palette['extended_import']       = g:ayu#palette['accent']
 endif
-
-" }}}
 
 function! ayu#get_style()
     return &background ==# 'dark' ? get(g:, 'ayucolor', 'dark') : &background

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -1,6 +1,6 @@
 " DO NOT EDIT
 " This file is generated using both the 'index.js' script and the 'ayu.extended.vim' file
-" Generated on 'Sun Mar 06 2022 14:26:29 GMT-0500 (Eastern Standard Time)'
+" Generated on 'Sun Mar 06 2022 17:44:45 GMT-0500 (Eastern Standard Time)'
 
 let g:ayu#palette = {}
 let g:ayu#palette['syntax_tag']                    = {'light': '#55b4d4', 'mirage': '#5ccfe6', 'dark': '#39bae6'}
@@ -50,10 +50,10 @@ if s:extended_palette
     let g:ayu#palette['extended_conditional']  = {'light': '#F9700C', 'mirage': '#FF8214', 'dark': '#FF710D'}
     let g:ayu#palette['extended_import']       = {'light': '#FF7E0D', 'mirage': '#FFBB33', 'dark': '#E0A123'}
 else
-    let g:ayu#palette['extended_keyword_func'] = g:ayu#palette['keyword']
-    let g:ayu#palette['extended_repeat']       = g:ayu#palette['keyword']
-    let g:ayu#palette['extended_conditional']  = g:ayu#palette['keyword']
-    let g:ayu#palette['extended_import']       = g:ayu#palette['accent']
+    let g:ayu#palette['extended_keyword_func'] = g:ayu#palette['syntax_keyword']
+    let g:ayu#palette['extended_repeat']       = g:ayu#palette['syntax_keyword']
+    let g:ayu#palette['extended_conditional']  = g:ayu#palette['syntax_keyword']
+    let g:ayu#palette['extended_import']       = g:ayu#palette['common_accent']
 endif
 
 function! ayu#get_style()

--- a/autoload/ayu.vim
+++ b/autoload/ayu.vim
@@ -1,4 +1,6 @@
-" File automatically generated on 'Sun Mar 06 2022 14:02:49 GMT-0500 (Eastern Standard Time)'
+" DO NOT EDIT
+" This file is generated using both the 'index.js' script and the 'ayu.extended.vim' file
+" Generated on 'Sun Mar 06 2022 14:26:29 GMT-0500 (Eastern Standard Time)'
 
 let g:ayu#palette = {}
 let g:ayu#palette['syntax_tag']                    = {'light': '#55b4d4', 'mirage': '#5ccfe6', 'dark': '#39bae6'}

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -42,8 +42,10 @@ call ayu#hi('NonText', 'editor_gutter_normal', '')
 call ayu#hi('Pmenu', 'editor_fg', 'ui_bg')
 call ayu#hi('PmenuSel', 'editor_fg', 'ui_bg', 'reverse')
 call ayu#hi('Question', 'syntax_string', '')
-" TODO: Use the 'editor_findMatch_active' background instead
-call ayu#hi('Search', 'editor_bg', 'syntax_constant')
+" TODO: This is what the theme should look like, but it might be more
+" difficult to see
+call ayu#hi('Search', '', 'editor_findMatch_inactive')
+call ayu#hi('IncSearch', '', 'editor_findMatch_active')
 call ayu#hi('SpecialKey', 'editor_selection_inactive', '')
 call ayu#hi('SpellCap', 'syntax_tag', '', 'underline')
 call ayu#hi('SpellLocal', 'syntax_keyword', '', 'underline')

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -39,8 +39,8 @@ call ayu#hi('MatchParen', 'editor_fg', 'editor_bg', 'underline')
 call ayu#hi('ModeMsg', 'syntax_string', '')
 call ayu#hi('MoreMsg', 'syntax_string', '')
 call ayu#hi('NonText', 'editor_gutter_normal', '')
-call ayu#hi('Pmenu', 'editor_fg', 'editor_selection_inactive')
-call ayu#hi('PmenuSel', 'editor_fg', 'editor_selection_inactive', 'reverse')
+call ayu#hi('Pmenu', 'editor_fg', 'ui_bg')
+call ayu#hi('PmenuSel', 'editor_fg', 'ui_bg', 'reverse')
 call ayu#hi('Question', 'syntax_string', '')
 " TODO: Use the 'editor_findMatch_active' background instead
 call ayu#hi('Search', 'editor_bg', 'syntax_constant')
@@ -67,8 +67,8 @@ call ayu#hi('Repeat', 'extended_repeat', '')
 
 " Neovim Highlights:" {{{
 
-call ayu#hi('NormalFloat', 'editor_fg', 'extended_float_bg')
-call ayu#hi('FloatBorder', 'editor_fg', 'extended_float_bg')
+call ayu#hi('NormalFloat', 'editor_fg', 'ui_panel_bg')
+call ayu#hi('FloatBorder', 'editor_fg', 'ui_panel_bg')
 
 " }}}
 

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -415,6 +415,32 @@ hi! link CompeDocumentation NormalFloat
 call ayu#hi('CmpItemAbbrMatch', 'common_accent', '')
 call ayu#hi('CmpItemAbbrMatchFuzzy', 'common_accent', '')
 
+" Highlights for cmp item types
+call ayu#hi('CmpItemAbbrDeprecated', '', '', 'strikethrough')
+
+call ayu#hi('CmpItemKindInterface', 'syntax_entity', '')
+call ayu#hi('CmpItemKindClass', 'syntax_entity', '')
+call ayu#hi('CmpItemKindEnum', 'syntax_entity', '')
+call ayu#hi('CmpItemKindStruct', 'syntax_entity', '')
+
+call ayu#hi('CmpItemKindFunction', 'syntax_func', '')
+call ayu#hi('CmpItemKindMethod', 'syntax_func', '')
+
+call ayu#hi('CmpItemKindKeyword', 'syntax_keyword', '')
+call ayu#hi('CmpItemKindOperator', 'syntax_keyword', '')
+
+call ayu#hi('CmpItemKindProperty', 'syntax_tag', '')
+call ayu#hi('CmpItemKindField', 'syntax_tag', '')
+
+call ayu#hi('CmpItemKindText', 'syntax_comment', '')
+call ayu#hi('CmpItemKindSnippet', 'syntax_comment', '')
+
+call ayu#hi('CmpItemKindModule', 'extended_import', '')
+
+call ayu#hi('CmpItemKindConstant', 'syntax_constant', '')
+
+call ayu#hi('CmpItemKindConstructor', 'common_accent', '')
+
 " }}}
 
 " Indent Blankline:" {{{

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -9,16 +9,9 @@ let g:colors_name = "ayu"
 let s:ayu_sign_contrast = get(g:, 'ayu_sign_contrast', 0)
 let s:ayu_italic_comment = get(g:, 'ayu_italic_comment', 0)
 
+let s:sign_bg = s:ayu_sign_contrast ? 'ui_bg' : ''
+
 "}}}
-
-" Helper Functions:"{{{
-
-" TODO: Maybe look into using 'ui_bg' for more constrast?
-function! s:sign_bg()
-    return s:ayu_sign_contrast ? 'ui_panel_bg' : ''
-endfunction
-
-" }}}
 
 " Vim Highlighting: (see :help highlight-groups)"{{{
 
@@ -31,9 +24,9 @@ call ayu#hi('LineNr', 'editor_gutter_normal', '')
 call ayu#hi('Directory', 'syntax_func', '')
 call ayu#hi('ErrorMsg', 'editor_fg', 'common_error', 'standout')
 call ayu#hi('VertSplit', 'ui_panel_bg', 'ui_panel_bg')
-call ayu#hi('Folded', 'extended_fg_idle', 'ui_panel_bg')
-call ayu#hi('FoldColumn', '', s:sign_bg())
-call ayu#hi('SignColumn', '', s:sign_bg())
+call ayu#hi('Folded', 'extended_fg_idle', 'ui_bg')
+call ayu#hi('FoldColumn', '', s:sign_bg)
+call ayu#hi('SignColumn', '', s:sign_bg)
 
 call ayu#hi('MatchParen', 'editor_fg', 'editor_bg', 'underline')
 call ayu#hi('ModeMsg', 'syntax_string', '')
@@ -163,17 +156,17 @@ call ayu#hi('netrwClassify', 'syntax_special', '')
 " }}}
 
 " GitGutter:" {{{
-call ayu#hi('GitGutterAdd', 'vcs_added', s:sign_bg())
-call ayu#hi('GitGutterChange', 'vcs_modified', s:sign_bg())
-call ayu#hi('GitGutterDelete', 'vcs_removed', s:sign_bg())
-call ayu#hi('GitGutterChangeDelete', 'vcs_modified', s:sign_bg(), 'underline')
+call ayu#hi('GitGutterAdd', 'vcs_added', s:sign_bg)
+call ayu#hi('GitGutterChange', 'vcs_modified', s:sign_bg)
+call ayu#hi('GitGutterDelete', 'vcs_removed', s:sign_bg)
+call ayu#hi('GitGutterChangeDelete', 'vcs_modified', s:sign_bg, 'underline')
 " }}}
 
 " Signify:" {{{
-call ayu#hi('SignifySignAdd', 'vcs_added', s:sign_bg())
-call ayu#hi('SignifySignChange', 'vcs_modified', s:sign_bg())
-call ayu#hi('SignifySignDelete', 'vcs_removed', s:sign_bg())
-call ayu#hi('SignifySignChangeDelete', 'vcs_modified', s:sign_bg(), 'underline')
+call ayu#hi('SignifySignAdd', 'vcs_added', s:sign_bg)
+call ayu#hi('SignifySignChange', 'vcs_modified', s:sign_bg)
+call ayu#hi('SignifySignDelete', 'vcs_removed', s:sign_bg)
+call ayu#hi('SignifySignChangeDelete', 'vcs_modified', s:sign_bg, 'underline')
 " }}}
 
 " NERDTree:" {{{
@@ -192,33 +185,33 @@ call ayu#hi('TelescopeMatching', 'common_accent', '')
 " Neovim Diagnostics:" {{{
 call ayu#hi('DiagnosticDefaultError', 'common_error', '')
 call ayu#hi('DiagnosticUnderlineError', 'common_error', '', 'underline')
-call ayu#hi('DiagnosticSignError', 'common_error', s:sign_bg())
+call ayu#hi('DiagnosticSignError', 'common_error', s:sign_bg)
 
 call ayu#hi('DiagnosticDefaultWarn', 'extended_warning', '')
 call ayu#hi('DiagnosticUnderlineWarn', 'extended_warning', '', 'underline')
-call ayu#hi('DiagnosticSignWarn', 'extended_warning', s:sign_bg())
+call ayu#hi('DiagnosticSignWarn', 'extended_warning', s:sign_bg)
 
 call ayu#hi('DiagnosticVirtualTextHint', 'extended_fg_idle', '')
-call ayu#hi('DiagnosticSignHint', 'editor_fg', s:sign_bg())
+call ayu#hi('DiagnosticSignHint', 'editor_fg', s:sign_bg)
 
 call ayu#hi('DiagnosticVirtualTextInfo', 'extended_fg_idle', '')
-call ayu#hi('DiagnosticSignInfo', 'editor_fg', s:sign_bg())
+call ayu#hi('DiagnosticSignInfo', 'editor_fg', s:sign_bg)
 " }}}
 
 " Neovim Builtin LSP:" {{{
 call ayu#hi('LspDiagnosticsDefaultError', 'common_error', '')
 call ayu#hi('LspDiagnosticsUnderlineError', 'common_error', '', 'underline')
-call ayu#hi('LspDiagnosticsSignError', 'common_error', s:sign_bg())
+call ayu#hi('LspDiagnosticsSignError', 'common_error', s:sign_bg)
 
 call ayu#hi('LspDiagnosticsDefaultWarning', 'extended_warning', '')
 call ayu#hi('LspDiagnosticsUnderlineWarning', 'extended_warning', '', 'underline')
-call ayu#hi('LspDiagnosticsSignWarning', 'extended_warning', s:sign_bg())
+call ayu#hi('LspDiagnosticsSignWarning', 'extended_warning', s:sign_bg)
 
 call ayu#hi('LspDiagnosticsVirtualTextHint', 'extended_fg_idle', '')
-call ayu#hi('LspDiagnosticsSignHint', 'editor_fg', s:sign_bg())
+call ayu#hi('LspDiagnosticsSignHint', 'editor_fg', s:sign_bg)
 
 call ayu#hi('LspDiagnosticsVirtualTextInformation', 'extended_fg_idle', '')
-call ayu#hi('LspDiagnosticsSignInformation', 'editor_fg', s:sign_bg())
+call ayu#hi('LspDiagnosticsSignInformation', 'editor_fg', s:sign_bg)
 
 hi! link LspReferenceRead Visual
 " }}}

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -33,10 +33,8 @@ call ayu#hi('ModeMsg', 'syntax_string', '')
 call ayu#hi('MoreMsg', 'syntax_string', '')
 call ayu#hi('NonText', 'editor_gutter_normal', '')
 call ayu#hi('Pmenu', 'editor_fg', 'ui_bg')
-call ayu#hi('PmenuSel', 'editor_fg', 'ui_bg', 'reverse')
+call ayu#hi('PmenuSel', '', 'ui_selection_active')
 call ayu#hi('Question', 'syntax_string', '')
-" TODO: This is what the theme should look like, but it might be more
-" difficult to see
 call ayu#hi('Search', '', 'editor_findMatch_inactive')
 call ayu#hi('IncSearch', '', 'editor_findMatch_active')
 call ayu#hi('SpecialKey', 'editor_selection_inactive', '')

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -13,150 +13,151 @@ let s:ayu_italic_comment = get(g:, 'ayu_italic_comment', 0)
 
 " Helper Functions:"{{{
 
+" TODO: Maybe look into using 'ui_bg' for more constrast?
 function! s:sign_bg()
-    return s:ayu_sign_contrast ? 'panel_bg' : ''
+    return s:ayu_sign_contrast ? 'ui_panel_bg' : ''
 endfunction
 
 " }}}
 
 " Vim Highlighting: (see :help highlight-groups)"{{{
 
-call ayu#hi('Normal', 'fg', 'bg')
-call ayu#hi('ColorColumn', '', 'line')
-call ayu#hi('CursorColumn', '', 'line')
-call ayu#hi('CursorLine', '', 'line')
-call ayu#hi('CursorLineNr', 'accent', 'line')
-call ayu#hi('LineNr', 'guide_normal', '')
-
-call ayu#hi('Directory', 'func', '')
-call ayu#hi('ErrorMsg', 'fg', 'error', 'standout')
-call ayu#hi('VertSplit', 'panel_bg', 'panel_bg')
-call ayu#hi('Folded', 'fg_idle', 'panel_bg')
+call ayu#hi('Normal', 'editor_fg', 'editor_bg')
+call ayu#hi('ColorColumn', '', 'editor_line')
+call ayu#hi('CursorColumn', '', 'editor_line')
+call ayu#hi('CursorLine', '', 'editor_line')
+call ayu#hi('CursorLineNr', 'common_accent', 'editor_line')
+call ayu#hi('LineNr', 'editor_gutter_normal', '')
+call ayu#hi('Directory', 'syntax_func', '')
+call ayu#hi('ErrorMsg', 'editor_fg', 'common_error', 'standout')
+call ayu#hi('VertSplit', 'ui_panel_bg', 'ui_panel_bg')
+call ayu#hi('Folded', 'extended_fg_idle', 'ui_panel_bg')
 call ayu#hi('FoldColumn', '', s:sign_bg())
 call ayu#hi('SignColumn', '', s:sign_bg())
 
-call ayu#hi('MatchParen', 'fg', 'bg', 'underline')
-call ayu#hi('ModeMsg', 'string', '')
-call ayu#hi('MoreMsg', 'string', '')
-call ayu#hi('NonText', 'guide_normal', '')
-call ayu#hi('Pmenu', 'fg', 'selection_inactive')
-call ayu#hi('PmenuSel', 'fg', 'selection_inactive', 'reverse')
-call ayu#hi('Question', 'string', '')
-call ayu#hi('Search', 'bg', 'constant')
-call ayu#hi('SpecialKey', 'selection_inactive', '')
-call ayu#hi('SpellCap', 'tag', '', 'underline')
-call ayu#hi('SpellLocal', 'keyword', '', 'underline')
-call ayu#hi('SpellBad', 'error', '', 'underline')
-call ayu#hi('SpellRare', 'regexp', '', 'underline')
-call ayu#hi('StatusLine', 'fg', 'panel_bg')
-call ayu#hi('StatusLineNC', 'fg_idle', 'panel_bg')
-call ayu#hi('WildMenu', 'fg', 'markup')
-call ayu#hi('TabLine', 'comment', 'panel_shadow')
-call ayu#hi('TabLineFill', 'fg', 'panel_border')
-call ayu#hi('TabLineSel', 'fg', 'bg')
-call ayu#hi('Title', 'keyword', '')
-call ayu#hi('Visual', '', 'selection_inactive')
-call ayu#hi('WarningMsg', 'warning', '')
+call ayu#hi('MatchParen', 'editor_fg', 'editor_bg', 'underline')
+call ayu#hi('ModeMsg', 'syntax_string', '')
+call ayu#hi('MoreMsg', 'syntax_string', '')
+call ayu#hi('NonText', 'editor_gutter_normal', '')
+call ayu#hi('Pmenu', 'editor_fg', 'editor_selection_inactive')
+call ayu#hi('PmenuSel', 'editor_fg', 'editor_selection_inactive', 'reverse')
+call ayu#hi('Question', 'syntax_string', '')
+" TODO: Use the 'editor_findMatch_active' background instead
+call ayu#hi('Search', 'editor_bg', 'syntax_constant')
+call ayu#hi('SpecialKey', 'editor_selection_inactive', '')
+call ayu#hi('SpellCap', 'syntax_tag', '', 'underline')
+call ayu#hi('SpellLocal', 'syntax_keyword', '', 'underline')
+call ayu#hi('SpellBad', 'common_error', '', 'underline')
+call ayu#hi('SpellRare', 'syntax_regexp', '', 'underline')
+call ayu#hi('StatusLine', 'editor_fg', 'ui_panel_bg')
+call ayu#hi('StatusLineNC', 'extended_fg_idle', 'ui_panel_bg')
+call ayu#hi('WildMenu', 'editor_fg', 'syntax_markup')
+call ayu#hi('TabLine', 'syntax_comment', 'ui_panel_shadow')
+call ayu#hi('TabLineFill', 'editor_fg', 'ui_bg')
+call ayu#hi('TabLineSel', 'editor_fg', 'editor_bg')
+call ayu#hi('Title', 'syntax_keyword', '')
+call ayu#hi('Visual', '', 'editor_selection_inactive')
+call ayu#hi('WarningMsg', 'extended_warning', '')
 
-" Experimental
-call ayu#hi('Conditional', 'conditional', '')
-call ayu#hi('Repeat', 'repeat', '')
+" Extended
+call ayu#hi('Conditional', 'extended_conditional', '')
+call ayu#hi('Repeat', 'extended_repeat', '')
 
 "}}}
 
 " Neovim Highlights:" {{{
 
-call ayu#hi('NormalFloat', 'fg', 'float_bg')
-call ayu#hi('FloatBorder', 'fg', 'float_bg')
+call ayu#hi('NormalFloat', 'editor_fg', 'extended_float_bg')
+call ayu#hi('FloatBorder', 'editor_fg', 'extended_float_bg')
 
 " }}}
 
 " Generic Syntax Highlighting: (see :help group-name)"{{{
 
-call ayu#hi('Comment', 'comment', '', s:ayu_italic_comment ? 'italic' : '')
+call ayu#hi('Comment', 'syntax_comment', '', s:ayu_italic_comment ? 'italic' : '')
 
-call ayu#hi('Constant', 'constant', '', '')
-call ayu#hi('String', 'string', '')
+call ayu#hi('Constant', 'syntax_constant', '', '')
+call ayu#hi('String', 'syntax_string', '')
 
-call ayu#hi('Identifier', 'entity', '')
-call ayu#hi('Function', 'func', '')
+call ayu#hi('Identifier', 'syntax_entity', '')
+call ayu#hi('Function', 'syntax_func', '')
 
-call ayu#hi('Statement', 'keyword', '')
-call ayu#hi('Operator', 'operator', '')
-call ayu#hi('Exception', 'markup', '')
+call ayu#hi('Statement', 'syntax_keyword', '')
+call ayu#hi('Operator', 'syntax_operator', '')
+call ayu#hi('Exception', 'syntax_markup', '')
 
-call ayu#hi('PreProc', 'accent', '')
+call ayu#hi('PreProc', 'common_accent', '')
 
-call ayu#hi('Type', 'entity', '')
-call ayu#hi('Structure', 'special', '')
+call ayu#hi('Type', 'syntax_entity', '')
+call ayu#hi('Structure', 'syntax_special', '')
 
-call ayu#hi('Special', 'accent', '')
-call ayu#hi('Delimiter', 'special', '')
+call ayu#hi('Special', 'common_accent', '')
+call ayu#hi('Delimiter', 'syntax_special', '')
 
-call ayu#hi('Underlined', 'tag', '', 'underline')
+call ayu#hi('Underlined', 'syntax_tag', '', 'underline')
 
 call ayu#hi('Ignore', '', '')
 
-call ayu#hi('Error', 'fg', 'error')
+call ayu#hi('Error', 'editor_fg', 'common_error')
 
-call ayu#hi('Todo', 'markup', '')
+call ayu#hi('Todo', 'syntax_markup', '')
 
 " Quickfix window highlighting
-call ayu#hi('qfLineNr', 'keyword', '')
+call ayu#hi('qfLineNr', 'syntax_keyword', '')
 
-call ayu#hi('Conceal', 'comment', '')
-call ayu#hi('CursorLineConceal', 'guide_normal', 'line')
+call ayu#hi('Conceal', 'syntax_comment', '')
+call ayu#hi('CursorLineConceal', 'editor_gutter_normal', 'editor_line')
 
-" Experimental
-call ayu#hi('PreCondit', 'conditional', '')
+" Extended
+call ayu#hi('PreCondit', 'extended_conditional', '')
 
 "}}}
 
 " Terminal: {{{
 
 if has("nvim")
-  let g:terminal_color_0 =  ayu#get_color('bg')
-  let g:terminal_color_1 =  ayu#get_color('markup')
-  let g:terminal_color_2 =  ayu#get_color('string')
-  let g:terminal_color_3 =  ayu#get_color('accent')
-  let g:terminal_color_4 =  ayu#get_color('tag')
-  let g:terminal_color_5 =  ayu#get_color('constant')
-  let g:terminal_color_6 =  ayu#get_color('regexp')
+  let g:terminal_color_0 =  ayu#get_color('editor_bg')
+  let g:terminal_color_1 =  ayu#get_color('syntax_markup')
+  let g:terminal_color_2 =  ayu#get_color('syntax_string')
+  let g:terminal_color_3 =  ayu#get_color('common_accent')
+  let g:terminal_color_4 =  ayu#get_color('syntax_tag')
+  let g:terminal_color_5 =  ayu#get_color('syntax_constant')
+  let g:terminal_color_6 =  ayu#get_color('syntax_regexp')
   let g:terminal_color_7 =  "#FFFFFF"
-  let g:terminal_color_8 =  ayu#get_color('fg_idle')
-  let g:terminal_color_9 =  ayu#get_color('error')
-  let g:terminal_color_10 = ayu#get_color('string')
-  let g:terminal_color_11 = ayu#get_color('accent')
-  let g:terminal_color_12 = ayu#get_color('tag')
-  let g:terminal_color_13 = ayu#get_color('constant')
-  let g:terminal_color_14 = ayu#get_color('regexp')
-  let g:terminal_color_15 = ayu#get_color('comment')
+  let g:terminal_color_8 =  ayu#get_color('extended_fg_idle')
+  let g:terminal_color_9 =  ayu#get_color('common_error')
+  let g:terminal_color_10 = ayu#get_color('syntax_string')
+  let g:terminal_color_11 = ayu#get_color('common_accent')
+  let g:terminal_color_12 = ayu#get_color('syntax_tag')
+  let g:terminal_color_13 = ayu#get_color('syntax_constant')
+  let g:terminal_color_14 = ayu#get_color('syntax_regexp')
+  let g:terminal_color_15 = ayu#get_color('syntax_comment')
   let g:terminal_color_background = g:terminal_color_0
-  let g:terminal_color_foreground = ayu#get_color('fg')
+  let g:terminal_color_foreground = ayu#get_color('editor_fg')
 else
-  let g:terminal_ansi_colors =  [ayu#get_color('bg'),        ayu#get_color('markup')]
-  let g:terminal_ansi_colors += [ayu#get_color('string'),  ayu#get_color('accent')]
-  let g:terminal_ansi_colors += [ayu#get_color('tag'),     ayu#get_color('constant')]
-  let g:terminal_ansi_colors += [ayu#get_color('regexp'),  "#FFFFFF"]
-  let g:terminal_ansi_colors += [ayu#get_color('fg_idle'), ayu#get_color('error')]
-  let g:terminal_ansi_colors += [ayu#get_color('string'),  ayu#get_color('accent')]
-  let g:terminal_ansi_colors += [ayu#get_color('tag'),     ayu#get_color('constant')]
-  let g:terminal_ansi_colors += [ayu#get_color('regexp'),  ayu#get_color('comment')]
+  let g:terminal_ansi_colors =  [ayu#get_color('editor_bg'),        ayu#get_color('syntax_markup')]
+  let g:terminal_ansi_colors += [ayu#get_color('syntax_string'),  ayu#get_color('common_accent')]
+  let g:terminal_ansi_colors += [ayu#get_color('syntax_tag'),     ayu#get_color('syntax_constant')]
+  let g:terminal_ansi_colors += [ayu#get_color('syntax_regexp'),  "#FFFFFF"]
+  let g:terminal_ansi_colors += [ayu#get_color('extended_fg_idle'), ayu#get_color('common_error')]
+  let g:terminal_ansi_colors += [ayu#get_color('syntax_string'),  ayu#get_color('common_accent')]
+  let g:terminal_ansi_colors += [ayu#get_color('syntax_tag'),     ayu#get_color('syntax_constant')]
+  let g:terminal_ansi_colors += [ayu#get_color('syntax_regexp'),  ayu#get_color('syntax_comment')]
 endif
 
 " }}}
 
 " Diff Syntax Highlighting:"{{{
-call ayu#hi('DiffAdd', 'vcs_added', 'guide_normal')
+call ayu#hi('DiffAdd', 'vcs_added', 'editor_gutter_normal')
 call ayu#hi('DiffAdded', 'vcs_added', '')
-call ayu#hi('DiffChange', 'vcs_modified', 'guide_normal')
-call ayu#hi('DiffDelete', 'vcs_removed', 'guide_normal')
+call ayu#hi('DiffChange', 'vcs_modified', 'editor_gutter_normal')
+call ayu#hi('DiffDelete', 'vcs_removed', 'editor_gutter_normal')
 call ayu#hi('DiffRemoved', 'vcs_removed', '')
-call ayu#hi('DiffText', 'vcs_modified', 'guide_active')
+call ayu#hi('DiffText', 'vcs_modified', 'editor_gutter_active')
 "}}}
 
 " Netrw:" {{{
-call ayu#hi('netrwClassify', 'special', '')
+call ayu#hi('netrwClassify', 'syntax_special', '')
 " }}}
 
 " GitGutter:" {{{
@@ -174,237 +175,237 @@ call ayu#hi('SignifySignChangeDelete', 'vcs_modified', s:sign_bg(), 'underline')
 " }}}
 
 " NERDTree:" {{{
-call ayu#hi('NERDTreeOpenable', 'fg_idle', '')
-call ayu#hi('NERDTreeClosable', 'accent', '')
-call ayu#hi('NERDTreeUp', 'fg_idle', '')
-call ayu#hi('NERDTreeDir', 'func', '')
+call ayu#hi('NERDTreeOpenable', 'extended_fg_idle', '')
+call ayu#hi('NERDTreeClosable', 'common_accent', '')
+call ayu#hi('NERDTreeUp', 'extended_fg_idle', '')
+call ayu#hi('NERDTreeDir', 'syntax_func', '')
 call ayu#hi('NERDTreeFile', '', '')
-call ayu#hi('NERDTreeDirSlash', 'special', '')
+call ayu#hi('NERDTreeDirSlash', 'syntax_special', '')
 " }}}
 
 " Telescope:"{{{
-call ayu#hi('TelescopeMatching', 'accent', '')
+call ayu#hi('TelescopeMatching', 'common_accent', '')
 " }}}
 
 " Neovim Diagnostics:" {{{
-call ayu#hi('DiagnosticDefaultError', 'error', '')
-call ayu#hi('DiagnosticUnderlineError', 'error', '', 'underline')
-call ayu#hi('DiagnosticSignError', 'error', s:sign_bg())
+call ayu#hi('DiagnosticDefaultError', 'common_error', '')
+call ayu#hi('DiagnosticUnderlineError', 'common_error', '', 'underline')
+call ayu#hi('DiagnosticSignError', 'common_error', s:sign_bg())
 
-call ayu#hi('DiagnosticDefaultWarn', 'warning', '')
-call ayu#hi('DiagnosticUnderlineWarn', 'warning', '', 'underline')
-call ayu#hi('DiagnosticSignWarn', 'warning', s:sign_bg())
+call ayu#hi('DiagnosticDefaultWarn', 'extended_warning', '')
+call ayu#hi('DiagnosticUnderlineWarn', 'extended_warning', '', 'underline')
+call ayu#hi('DiagnosticSignWarn', 'extended_warning', s:sign_bg())
 
-call ayu#hi('DiagnosticVirtualTextHint', 'fg_idle', '')
-call ayu#hi('DiagnosticSignHint', 'fg', s:sign_bg())
+call ayu#hi('DiagnosticVirtualTextHint', 'extended_fg_idle', '')
+call ayu#hi('DiagnosticSignHint', 'editor_fg', s:sign_bg())
 
-call ayu#hi('DiagnosticVirtualTextInfo', 'fg_idle', '')
-call ayu#hi('DiagnosticSignInfo', 'fg', s:sign_bg())
+call ayu#hi('DiagnosticVirtualTextInfo', 'extended_fg_idle', '')
+call ayu#hi('DiagnosticSignInfo', 'editor_fg', s:sign_bg())
 " }}}
 
 " Neovim Builtin LSP:" {{{
-call ayu#hi('LspDiagnosticsDefaultError', 'error', '')
-call ayu#hi('LspDiagnosticsUnderlineError', 'error', '', 'underline')
-call ayu#hi('LspDiagnosticsSignError', 'error', s:sign_bg())
+call ayu#hi('LspDiagnosticsDefaultError', 'common_error', '')
+call ayu#hi('LspDiagnosticsUnderlineError', 'common_error', '', 'underline')
+call ayu#hi('LspDiagnosticsSignError', 'common_error', s:sign_bg())
 
-call ayu#hi('LspDiagnosticsDefaultWarning', 'warning', '')
-call ayu#hi('LspDiagnosticsUnderlineWarning', 'warning', '', 'underline')
-call ayu#hi('LspDiagnosticsSignWarning', 'warning', s:sign_bg())
+call ayu#hi('LspDiagnosticsDefaultWarning', 'extended_warning', '')
+call ayu#hi('LspDiagnosticsUnderlineWarning', 'extended_warning', '', 'underline')
+call ayu#hi('LspDiagnosticsSignWarning', 'extended_warning', s:sign_bg())
 
-call ayu#hi('LspDiagnosticsVirtualTextHint', 'fg_idle', '')
-call ayu#hi('LspDiagnosticsSignHint', 'fg', s:sign_bg())
+call ayu#hi('LspDiagnosticsVirtualTextHint', 'extended_fg_idle', '')
+call ayu#hi('LspDiagnosticsSignHint', 'editor_fg', s:sign_bg())
 
-call ayu#hi('LspDiagnosticsVirtualTextInformation', 'fg_idle', '')
-call ayu#hi('LspDiagnosticsSignInformation', 'fg', s:sign_bg())
+call ayu#hi('LspDiagnosticsVirtualTextInformation', 'extended_fg_idle', '')
+call ayu#hi('LspDiagnosticsSignInformation', 'editor_fg', s:sign_bg())
 
 hi! link LspReferenceRead Visual
 " }}}
 
 " YATS:" {{{
 
-call ayu#hi('typescriptDecorator', 'markup', '')
-call ayu#hi('typescriptImport', 'import', '')
-call ayu#hi('typescriptExport', 'accent', '')
-call ayu#hi('typescriptIdentifier', 'tag', '', 'italic')
-call ayu#hi('typescriptAssign', 'operator', '')
-call ayu#hi('typescriptBinaryOp', 'operator', '')
-call ayu#hi('typescriptTernaryOp', 'operator', '')
-call ayu#hi('typescriptModule', 'keyword', '')
-call ayu#hi('typescriptTypeBrackets', 'special', '')
-call ayu#hi('typescriptClassName', 'tag', '')
-call ayu#hi('typescriptAmbientDeclaration', 'keyword', '')
-call ayu#hi('typescriptRegexpString', 'regexp', '')
-call ayu#hi('typescriptTry', 'markup', '')
-call ayu#hi('typescriptExceptions', 'markup', '')
-call ayu#hi('typescriptDebugger', 'markup', '', 'bold')
-call ayu#hi('typescriptParens', 'special', '')
-"call ayu#hi('typescriptVariable', 'keyword', '')
-call ayu#hi('typescriptObjectLabel', 'tag', '')
-call ayu#hi('typescriptOperator', 'keyword', '')
-call ayu#hi('typescriptArrowFunc', 'operator', '')
-call ayu#hi('typescriptBraces', 'special', '')
-call ayu#hi('typescriptGlobal', 'accent', '')
+call ayu#hi('typescriptDecorator', 'syntax_markup', '')
+call ayu#hi('typescriptImport', 'extended_import', '')
+call ayu#hi('typescriptExport', 'common_accent', '')
+call ayu#hi('typescriptIdentifier', 'syntax_tag', '', 'italic')
+call ayu#hi('typescriptAssign', 'syntax_operator', '')
+call ayu#hi('typescriptBinaryOp', 'syntax_operator', '')
+call ayu#hi('typescriptTernaryOp', 'syntax_operator', '')
+call ayu#hi('typescriptModule', 'syntax_keyword', '')
+call ayu#hi('typescriptTypeBrackets', 'syntax_special', '')
+call ayu#hi('typescriptClassName', 'syntax_tag', '')
+call ayu#hi('typescriptAmbientDeclaration', 'syntax_keyword', '')
+call ayu#hi('typescriptRegexpString', 'syntax_regexp', '')
+call ayu#hi('typescriptTry', 'syntax_markup', '')
+call ayu#hi('typescriptExceptions', 'syntax_markup', '')
+call ayu#hi('typescriptDebugger', 'syntax_markup', '', 'bold')
+call ayu#hi('typescriptParens', 'syntax_special', '')
+"call ayu#hi('typescriptVariable', 'syntax_keyword', '')
+call ayu#hi('typescriptObjectLabel', 'syntax_tag', '')
+call ayu#hi('typescriptOperator', 'syntax_keyword', '')
+call ayu#hi('typescriptArrowFunc', 'syntax_operator', '')
+call ayu#hi('typescriptBraces', 'syntax_special', '')
+call ayu#hi('typescriptGlobal', 'common_accent', '')
 
 " Prop
-call ayu#hi('typescriptDOMFormProp', 'entity', '')
-call ayu#hi('typescriptDOMEventProp', 'entity', '')
-call ayu#hi('typescriptBOMWindowProp', 'accent', '')
+call ayu#hi('typescriptDOMFormProp', 'syntax_entity', '')
+call ayu#hi('typescriptDOMEventProp', 'syntax_entity', '')
+call ayu#hi('typescriptBOMWindowProp', 'common_accent', '')
 
 " Method
-call ayu#hi('typescriptDateMethod', 'func', '')
-call ayu#hi('typescriptBlobMethod', 'func', '')
-call ayu#hi('typescriptArrayMethod', 'func', '')
-call ayu#hi('typescriptArrayStaticMethod', 'func', '')
-call ayu#hi('typescriptStringMethod', 'func', '')
-call ayu#hi('typescriptPaymentMethod', 'func', '')
-call ayu#hi('typescriptHeadersMethod', 'func', '')
-call ayu#hi('typescriptCacheMethod', 'func', '')
-call ayu#hi('typescriptDOMEventMethod', 'func', '')
-call ayu#hi('typescriptDOMEventTargetMethod', 'func', '')
-call ayu#hi('typescriptBOMWindowMethod', 'func', '')
-call ayu#hi('typescriptDOMStorageMethod', 'func', '')
-call ayu#hi('typescriptPromiseMethod', 'func', '')
-call ayu#hi('typescriptGlobalMethod', 'func', '')
-call ayu#hi('typescriptFunctionMethod', 'func', '')
-call ayu#hi('typescriptBOMLocationMethod', 'func', '')
+call ayu#hi('typescriptDateMethod', 'syntax_func', '')
+call ayu#hi('typescriptBlobMethod', 'syntax_func', '')
+call ayu#hi('typescriptArrayMethod', 'syntax_func', '')
+call ayu#hi('typescriptArrayStaticMethod', 'syntax_func', '')
+call ayu#hi('typescriptStringMethod', 'syntax_func', '')
+call ayu#hi('typescriptPaymentMethod', 'syntax_func', '')
+call ayu#hi('typescriptHeadersMethod', 'syntax_func', '')
+call ayu#hi('typescriptCacheMethod', 'syntax_func', '')
+call ayu#hi('typescriptDOMEventMethod', 'syntax_func', '')
+call ayu#hi('typescriptDOMEventTargetMethod', 'syntax_func', '')
+call ayu#hi('typescriptBOMWindowMethod', 'syntax_func', '')
+call ayu#hi('typescriptDOMStorageMethod', 'syntax_func', '')
+call ayu#hi('typescriptPromiseMethod', 'syntax_func', '')
+call ayu#hi('typescriptGlobalMethod', 'syntax_func', '')
+call ayu#hi('typescriptFunctionMethod', 'syntax_func', '')
+call ayu#hi('typescriptBOMLocationMethod', 'syntax_func', '')
 
-" Experimental
-call ayu#hi('typescriptFuncKeyword', 'keyword_func', '')
-call ayu#hi('typescriptConditional', 'conditional', '')
-call ayu#hi('typescriptCase', 'conditional', '')
-call ayu#hi('typescriptRepeat', 'repeat', '')
-call ayu#hi('typescriptBranch', 'repeat', '')
+" Extended
+call ayu#hi('typescriptFuncKeyword', 'extended_keyword_func', '')
+call ayu#hi('typescriptConditional', 'extended_conditional', '')
+call ayu#hi('typescriptCase', 'extended_conditional', '')
+call ayu#hi('typescriptRepeat', 'extended_repeat', '')
+call ayu#hi('typescriptBranch', 'extended_repeat', '')
 
 " }}}
 
 " Javascript:" {{{
 
-call ayu#hi('jsNull', 'constant', '')
-call ayu#hi('jsThis', 'constant', '', 'italic')
+call ayu#hi('jsNull', 'syntax_constant', '')
+call ayu#hi('jsThis', 'syntax_constant', '', 'italic')
 
-call ayu#hi('jsBrackets', 'special', '')
-call ayu#hi('jsDot', 'special', '')
-call ayu#hi('jsParens', 'special', '')
-call ayu#hi('jsFuncParens', 'special', '')
-call ayu#hi('jsFuncBraces', 'special', '')
-call ayu#hi('jsIfElseBraces', 'special', '')
+call ayu#hi('jsBrackets', 'syntax_special', '')
+call ayu#hi('jsDot', 'syntax_special', '')
+call ayu#hi('jsParens', 'syntax_special', '')
+call ayu#hi('jsFuncParens', 'syntax_special', '')
+call ayu#hi('jsFuncBraces', 'syntax_special', '')
+call ayu#hi('jsIfElseBraces', 'syntax_special', '')
 
-call ayu#hi('jsObjectKey', 'tag', '')
-call ayu#hi('jsObjectProp', 'tag', '')
+call ayu#hi('jsObjectKey', 'syntax_tag', '')
+call ayu#hi('jsObjectProp', 'syntax_tag', '')
 
-call ayu#hi('jsRegexpString', 'regexp', '')
+call ayu#hi('jsRegexpString', 'syntax_regexp', '')
 
-call ayu#hi('jsStorageClass', 'keyword', '')
+call ayu#hi('jsStorageClass', 'syntax_keyword', '')
 
-call ayu#hi('jsArrowFunction', 'operator', '')
+call ayu#hi('jsArrowFunction', 'syntax_operator', '')
 
-" Experimental
-call ayu#hi('jsFunction', 'keyword_func', '')
+" Extended
+call ayu#hi('jsFunction', 'extended_keyword_func', '')
 
 " }}}
 
 " TreeSitter:" {{{
 
-call ayu#hi('TSInclude', 'import', '')
+call ayu#hi('TSInclude', 'extended_import', '')
 
-call ayu#hi('TSParameter', 'special', '')
+call ayu#hi('TSParameter', 'syntax_special', '')
 
-call ayu#hi('TSField', 'tag', '')
-call ayu#hi('TSProperty', 'tag', '')
+call ayu#hi('TSField', 'syntax_tag', '')
+call ayu#hi('TSProperty', 'syntax_tag', '')
 
-call ayu#hi('TSAttribute', 'markup', '')
+call ayu#hi('TSAttribute', 'syntax_markup', '')
 
-call ayu#hi('TSVariableBuiltin', 'constant', '', 'italic')
-call ayu#hi('TSConstBuiltin', 'constant', '')
+call ayu#hi('TSVariableBuiltin', 'syntax_constant', '', 'italic')
+call ayu#hi('TSConstBuiltin', 'syntax_constant', '')
 
-call ayu#hi('TSStringRegex', 'regexp', '')
+call ayu#hi('TSStringRegex', 'syntax_regexp', '')
 
-call ayu#hi('TSFuncMacro', 'func', '')
+call ayu#hi('TSFuncMacro', 'syntax_func', '')
 
-" Experimental
-call ayu#hi('TSKeywordFunction', 'keyword_func', '')
-call ayu#hi('TSRepeat', 'repeat', '')
-call ayu#hi('TSConditional', 'conditional', '')
+" Extended
+call ayu#hi('TSKeywordFunction', 'extended_keyword_func', '')
+call ayu#hi('TSRepeat', 'extended_repeat', '')
+call ayu#hi('TSConditional', 'extended_conditional', '')
 
 " }}}
 
 " Fugitive:" {{{
-call ayu#hi('fugitiveUntrackedHeading', 'accent', '')
-call ayu#hi('fugitiveUnstagedHeading', 'accent', '')
-call ayu#hi('fugitiveStagedHeading', 'accent', '')
-call ayu#hi('fugitiveHeading', 'accent', '')
+call ayu#hi('fugitiveUntrackedHeading', 'common_accent', '')
+call ayu#hi('fugitiveUnstagedHeading', 'common_accent', '')
+call ayu#hi('fugitiveStagedHeading', 'common_accent', '')
+call ayu#hi('fugitiveHeading', 'common_accent', '')
 " }}}
 
 " Git Commit:" {{{
-call ayu#hi('gitcommitBranch', 'func', '')
-call ayu#hi('gitcommitHeader', 'accent', '')
-call ayu#hi('gitcommitSummary', 'fg', '')
-call ayu#hi('gitcommitOverflow', 'markup', '')
+call ayu#hi('gitcommitBranch', 'syntax_func', '')
+call ayu#hi('gitcommitHeader', 'common_accent', '')
+call ayu#hi('gitcommitSummary', 'editor_fg', '')
+call ayu#hi('gitcommitOverflow', 'syntax_markup', '')
 " }}}
 
 " Startify:" {{{
-call ayu#hi('StartifyFile', 'fg', '')
+call ayu#hi('StartifyFile', 'editor_fg', '')
 " }}}
 
 " Vim:" {{{
-call ayu#hi('vimUserFunc', 'func', '')
+call ayu#hi('vimUserFunc', 'syntax_func', '')
 hi! link vimVar NONE
-call ayu#hi('vimFunction', 'func', '')
+call ayu#hi('vimFunction', 'syntax_func', '')
 call ayu#hi('vimIsCommand', '', '')
 " }}}
 
 " XML:" {{{
 
-call ayu#hi('xmlTag', 'special', '')
-call ayu#hi('xmlTagName', 'keyword', '')
-call ayu#hi('xmlEntity', 'tag', '')
-call ayu#hi('xmlEntityPunct', 'operator', '')
-call ayu#hi('xmlEqual', 'operator', '')
+call ayu#hi('xmlTag', 'syntax_special', '')
+call ayu#hi('xmlTagName', 'syntax_keyword', '')
+call ayu#hi('xmlEntity', 'syntax_tag', '')
+call ayu#hi('xmlEntityPunct', 'syntax_operator', '')
+call ayu#hi('xmlEqual', 'syntax_operator', '')
 
 " }}}
 
 " INI:" {{{
-call ayu#hi('dosiniHeader', 'keyword', '')
+call ayu#hi('dosiniHeader', 'syntax_keyword', '')
 " }}}
 
 " Pandoc:" {{{
 
-call ayu#hi('pandocPipeTableHeader', 'keyword', '')
-call ayu#hi('pandocPipeTableDelims', 'keyword', '')
-call ayu#hi('pandocDelimitedCodeBlock', 'accent', '')
+call ayu#hi('pandocPipeTableHeader', 'syntax_keyword', '')
+call ayu#hi('pandocPipeTableDelims', 'syntax_keyword', '')
+call ayu#hi('pandocDelimitedCodeBlock', 'common_accent', '')
 
 " }}}
 
 " Shell:" {{{
 
-call ayu#hi('shTestOpr', 'operator', '')
-call ayu#hi('shOption', 'special', '')
-call ayu#hi('shQuote', 'string', '')
+call ayu#hi('shTestOpr', 'syntax_operator', '')
+call ayu#hi('shOption', 'syntax_special', '')
+call ayu#hi('shQuote', 'syntax_string', '')
 
 " }}}
 
 " Haskell:" {{{
 
-call ayu#hi('haskellDeclKeyword', 'keyword', '')
-call ayu#hi('haskellLet', 'keyword', '')
-call ayu#hi('haskellWhere', 'keyword', '')
-call ayu#hi('haskellIdentifier', 'tag', '')
+call ayu#hi('haskellDeclKeyword', 'syntax_keyword', '')
+call ayu#hi('haskellLet', 'syntax_keyword', '')
+call ayu#hi('haskellWhere', 'syntax_keyword', '')
+call ayu#hi('haskellIdentifier', 'syntax_tag', '')
 
 " }}}
 
 " PHP:" {{{
 
-call ayu#hi('phpDefine', 'keyword', '')
-call ayu#hi('phpStructure', 'keyword', '')
+call ayu#hi('phpDefine', 'syntax_keyword', '')
+call ayu#hi('phpStructure', 'syntax_keyword', '')
 
 " }}}
 
 " Ruby:" {{{
 
-call ayu#hi('rubyModule', 'keyword', '')
-call ayu#hi('rubyRegexp', 'regexp', '')
-call ayu#hi('rubyRegexpDelimiter', 'regexp', '')
-call ayu#hi('rubyStringDelimiter', 'string', '')
+call ayu#hi('rubyModule', 'syntax_keyword', '')
+call ayu#hi('rubyRegexp', 'syntax_regexp', '')
+call ayu#hi('rubyRegexpDelimiter', 'syntax_regexp', '')
+call ayu#hi('rubyStringDelimiter', 'syntax_string', '')
 
 " }}}
 

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -416,3 +416,17 @@ call ayu#hi('rubyStringDelimiter', 'syntax_string', '')
 hi! link CompeDocumentation NormalFloat
 
 " }}}
+
+" Cmp:" {{{
+
+call ayu#hi('CmpItemAbbrMatch', 'common_accent', '')
+call ayu#hi('CmpItemAbbrMatchFuzzy', 'common_accent', '')
+
+" }}}
+
+" Indent Blankline:" {{{
+
+call ayu#hi('IndentBlanklineChar', 'editor_indentGuide_normal', '')
+call ayu#hi('IndentBlanklineContextChar', 'editor_indentGuide_active', '')
+
+" }}}

--- a/generator/.gitignore
+++ b/generator/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+ayu.vim

--- a/generator/ayu.extended.vim
+++ b/generator/ayu.extended.vim
@@ -1,39 +1,19 @@
 let s:extended_palette = get(g:, 'ayu_extended_palette', 0)
 
-let g:ayu#palette['light']['extended_fg_idle'] = '#828C99'
-let g:ayu#palette['mirage']['extended_fg_idle'] = '#607080'
-let g:ayu#palette['dark']['extended_fg_idle'] = '#3E4B59'
-
-let g:ayu#palette['light']['extended_warning'] = '#FA8D3E'
-let g:ayu#palette['mirage']['extended_warning'] = '#FFA759'
-let g:ayu#palette['dark']['extended_warning'] = '#FF8F40'
-
-let g:ayu#palette['light']['extended_float_bg'] = '#D8D8D8'
-let g:ayu#palette['mirage']['extended_float_bg'] = '#2D323F'
-let g:ayu#palette['dark']['extended_float_bg'] = '#161e26'
+let g:ayu#palette['extended_fg_idle']          = {'light': '#828C99', 'mirage': '#607080', 'dark': '#3E4B59'}
+let g:ayu#palette['extended_warning']          = {'light': '#FA8D3E', 'mirage': '#FFA759', 'dark': '#FF8F40'}
+let g:ayu#palette['extended_float_bg']         = {'light': '#D8D8D8', 'mirage': '#2D323F', 'dark': '#161e26'}
 
 if s:extended_palette
-    let g:ayu#palette['light']['extended_keyword_func']  = '#3EABFA'
-    let g:ayu#palette['light']['extended_repeat']        = '#FA3E4D'
-    let g:ayu#palette['light']['extended_conditional']   = '#F9700C'
-    let g:ayu#palette['light']['accent']                 = '#FF7E0D'
-
-    let g:ayu#palette['mirage']['extended_keyword_func'] = '#80AAFF'
-    let g:ayu#palette['mirage']['extended_repeat']       = '#FF595E'
-    let g:ayu#palette['mirage']['extended_conditional']  = '#FF8214'
-    let g:ayu#palette['mirage']['accent']                = '#FFBB33'
-
-    let g:ayu#palette['dark']['extended_keyword_func']   = '#40B0FF'
-    let g:ayu#palette['dark']['extended_repeat']         = '#FF4051'
-    let g:ayu#palette['dark']['extended_conditional']    = '#FF710D'
-    let g:ayu#palette['dark']['accent']                  = '#E0A123'
+    let g:ayu#palette['extended_keyword_func'] = {'light': '#3EABFA', 'mirage': '#80AAFF', 'dark': '#40B0FF'}
+    let g:ayu#palette['extended_repeat']       = {'light': '#FA3E4D', 'mirage': '#FF595E', 'dark': '#FF4051'}
+    let g:ayu#palette['extended_conditional']  = {'light': '#F9700C', 'mirage': '#FF8214', 'dark': '#FF710D'}
+    let g:ayu#palette['extended_import']       = {'light': '#FF7E0D', 'mirage': '#FFBB33', 'dark': '#E0A123'}
 else
-    for style in ['light', 'mirage', 'dark']
-        let g:ayu#palette[style]['extended_keyword_func'] = g:ayu#palette[style]['keyword']
-        let g:ayu#palette[style]['extended_repeat']       = g:ayu#palette[style]['keyword']
-        let g:ayu#palette[style]['extended_conditional']  = g:ayu#palette[style]['keyword']
-        let g:ayu#palette[style]['import']                = g:ayu#palette[style]['accent']
-    endfor
+    let g:ayu#palette['extended_keyword_func'] = g:ayu#palette['keyword']
+    let g:ayu#palette['extended_repeat']       = g:ayu#palette['keyword']
+    let g:ayu#palette['extended_conditional']  = g:ayu#palette['keyword']
+    let g:ayu#palette['extended_import']       = g:ayu#palette['accent']
 endif
 
 function! ayu#get_style()
@@ -43,7 +23,7 @@ endfunction
 function! ayu#get_color(color_name)
     let l:style = ayu#get_style()
 
-    return g:ayu#palette[l:style][a:color_name]
+    return g:ayu#palette[a:color_name][l:style]
 endfunction
 
 function! ayu#hi(group_name, fg_color_name, bg_color_name, ...)

--- a/generator/ayu.extended.vim
+++ b/generator/ayu.extended.vim
@@ -1,0 +1,65 @@
+let s:extended_palette = get(g:, 'ayu_extended_palette', 0)
+
+let g:ayu#palette['light']['extended_fg_idle'] = '#828C99'
+let g:ayu#palette['mirage']['extended_fg_idle'] = '#607080'
+let g:ayu#palette['dark']['extended_fg_idle'] = '#3E4B59'
+
+let g:ayu#palette['light']['extended_warning'] = '#FA8D3E'
+let g:ayu#palette['mirage']['extended_warning'] = '#FFA759'
+let g:ayu#palette['dark']['extended_warning'] = '#FF8F40'
+
+let g:ayu#palette['light']['extended_float_bg'] = '#D8D8D8'
+let g:ayu#palette['mirage']['extended_float_bg'] = '#2D323F'
+let g:ayu#palette['dark']['extended_float_bg'] = '#161e26'
+
+if s:extended_palette
+    let g:ayu#palette['light']['extended_keyword_func']  = '#3EABFA'
+    let g:ayu#palette['light']['extended_repeat']        = '#FA3E4D'
+    let g:ayu#palette['light']['extended_conditional']   = '#F9700C'
+    let g:ayu#palette['light']['accent']                 = '#FF7E0D'
+
+    let g:ayu#palette['mirage']['extended_keyword_func'] = '#80AAFF'
+    let g:ayu#palette['mirage']['extended_repeat']       = '#FF595E'
+    let g:ayu#palette['mirage']['extended_conditional']  = '#FF8214'
+    let g:ayu#palette['mirage']['accent']                = '#FFBB33'
+
+    let g:ayu#palette['dark']['extended_keyword_func']   = '#40B0FF'
+    let g:ayu#palette['dark']['extended_repeat']         = '#FF4051'
+    let g:ayu#palette['dark']['extended_conditional']    = '#FF710D'
+    let g:ayu#palette['dark']['accent']                  = '#E0A123'
+else
+    for style in ['light', 'mirage', 'dark']
+        let g:ayu#palette[style]['extended_keyword_func'] = g:ayu#palette[style]['keyword']
+        let g:ayu#palette[style]['extended_repeat']       = g:ayu#palette[style]['keyword']
+        let g:ayu#palette[style]['extended_conditional']  = g:ayu#palette[style]['keyword']
+        let g:ayu#palette[style]['import']                = g:ayu#palette[style]['accent']
+    endfor
+endif
+
+function! ayu#get_style()
+    return &background ==# 'dark' ? get(g:, 'ayucolor', 'dark') : &background
+endfunction
+
+function! ayu#get_color(color_name)
+    let l:style = ayu#get_style()
+
+    return g:ayu#palette[l:style][a:color_name]
+endfunction
+
+function! ayu#hi(group_name, fg_color_name, bg_color_name, ...)
+    let l:highlights = ['hi!', a:group_name]
+
+    let l:fg_color = a:fg_color_name !=# '' ? ayu#get_color(a:fg_color_name) : 'NONE'
+    call add(l:highlights, 'guifg=' . l:fg_color)
+
+    let l:bg_color = a:bg_color_name !=# '' ? ayu#get_color(a:bg_color_name) : 'NONE'
+    call add(l:highlights, 'guibg=' . l:bg_color)
+
+    let l:fmt_arg = get(a:, '1')
+    let l:fmt = l:fmt_arg !=# '0' && l:fmt_arg !=# '' ? l:fmt_arg : 'NONE'
+    call add(l:highlights, 'gui=' . l:fmt)
+    call add(l:highlights, 'cterm=' . l:fmt)
+
+    let l:cmd = join(l:highlights, ' ')
+    execute l:cmd
+endfunction

--- a/generator/ayu.extended.vim
+++ b/generator/ayu.extended.vim
@@ -10,10 +10,10 @@ if s:extended_palette
     let g:ayu#palette['extended_conditional']  = {'light': '#F9700C', 'mirage': '#FF8214', 'dark': '#FF710D'}
     let g:ayu#palette['extended_import']       = {'light': '#FF7E0D', 'mirage': '#FFBB33', 'dark': '#E0A123'}
 else
-    let g:ayu#palette['extended_keyword_func'] = g:ayu#palette['keyword']
-    let g:ayu#palette['extended_repeat']       = g:ayu#palette['keyword']
-    let g:ayu#palette['extended_conditional']  = g:ayu#palette['keyword']
-    let g:ayu#palette['extended_import']       = g:ayu#palette['accent']
+    let g:ayu#palette['extended_keyword_func'] = g:ayu#palette['syntax_keyword']
+    let g:ayu#palette['extended_repeat']       = g:ayu#palette['syntax_keyword']
+    let g:ayu#palette['extended_conditional']  = g:ayu#palette['syntax_keyword']
+    let g:ayu#palette['extended_import']       = g:ayu#palette['common_accent']
 endif
 
 function! ayu#get_style()

--- a/generator/index.js
+++ b/generator/index.js
@@ -2,7 +2,9 @@ import { light, mirage, dark } from 'ayu';
 import * as fs from 'fs';
 
 const currentDate = new Date();
-let fileContent = `" File automatically generated on '${currentDate}'\n\n`;
+let fileContent = `" DO NOT EDIT
+" This file is generated using both the 'index.js' script and the 'ayu.extended.vim' file
+" Generated on '${currentDate}'\n\n`;
 
 fileContent += 'let g:ayu#palette = {}\n';
 

--- a/generator/index.js
+++ b/generator/index.js
@@ -28,6 +28,10 @@ fs.writeFileSync('./ayu.vim', fileContent);
 function getColorDict(group, color, state) {
     let lightHex, mirageHex, darkHex;
     if (typeof state === 'undefined') {
+        // TODO: Blend is nice, but there are multiple backgrounds possible, it
+        // is possible that we do not use the same background in vim.
+        // Maybe we would need to blend it with the multiple possible
+        // backgrounds.
         lightHex = light[group][color].hex('blend');
         mirageHex = mirage[group][color].hex('blend');
         darkHex = dark[group][color].hex('blend');

--- a/generator/index.js
+++ b/generator/index.js
@@ -1,0 +1,59 @@
+import { light, mirage, dark } from 'ayu';
+import * as fs from 'fs';
+
+const currentDate = new Date();
+let fileContent = '';
+fileContent += `" File automatically generated on '${currentDate}'\n\n`;
+
+fileContent += 'let g:ayu#palette = {\n';
+
+fileContent += "\t\\\t'light': {\n";
+fileContent += getFileContentFromColorStyle(light);
+fileContent += '\t\\\t},\n';
+
+fileContent += "\t\\\t'mirage': {\n";
+fileContent += getFileContentFromColorStyle(mirage);
+fileContent += '\t\\\t},\n';
+
+fileContent += "\t\\\t'dark': {\n";
+fileContent += getFileContentFromColorStyle(dark);
+fileContent += '\t\\\t}\n';
+
+fileContent += '\t\\}\n';
+
+// TODO: Extended color palette
+// TODO: Helper vimscript functions
+// IDEA: Maybe these could be added into another file that's either separate or simply added to the end of this one
+
+fs.writeFileSync('./ayu.vim', fileContent);
+
+function getFileContentFromColorStyle(colorStyle) {
+    let ret = '';
+    for (let group in colorStyle) {
+        for (let color in colorStyle[group]) {
+            if (isClass(colorStyle[group][color])) { // Is a "Color" class
+                const hex = colorStyle[group][color].hex('blend');
+                ret += `\t\\\t\t'${group}_${color}': '${hex}',\n`;
+            } else {
+                for (let state in colorStyle[group][color]) {
+                    const hex = colorStyle[group][color][state].hex('blend');
+                    ret += `\t\\\t\t'${group}_${state}_${color}': '${hex}',\n`;
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+function isClass(obj) {
+    const isCtorClass = obj.constructor
+        && obj.constructor.toString().substring(0, 5) === 'class'
+    if (obj.prototype === undefined) {
+        return isCtorClass
+    }
+    const isPrototypeCtorClass = obj.prototype.constructor
+        && obj.prototype.constructor.toString
+        && obj.prototype.constructor.toString().substring(0, 5) === 'class'
+    return isCtorClass || isPrototypeCtorClass
+}

--- a/generator/index.js
+++ b/generator/index.js
@@ -1,29 +1,26 @@
 import { light, mirage, dark } from 'ayu';
 import * as fs from 'fs';
 
+// TODO: Create the same structure as what was used before. It was simpler to
+// read and less verbose than this one.
+
 const currentDate = new Date();
-let fileContent = '';
-fileContent += `" File automatically generated on '${currentDate}'\n\n`;
+let fileContent = `" File automatically generated on '${currentDate}'
+let g:ayu#palette = {
+    \\    'light': {
+${getFileContentFromColorStyle(light)}
+    \\    },
+    \\    'mirage': {
+${getFileContentFromColorStyle(mirage)}
+    \\    },
+    \\    'dark': {
+${getFileContentFromColorStyle(dark)}
+    \\    }
+    \\}
 
-fileContent += 'let g:ayu#palette = {\n';
+`;
 
-fileContent += "\t\\\t'light': {\n";
-fileContent += getFileContentFromColorStyle(light);
-fileContent += '\t\\\t},\n';
-
-fileContent += "\t\\\t'mirage': {\n";
-fileContent += getFileContentFromColorStyle(mirage);
-fileContent += '\t\\\t},\n';
-
-fileContent += "\t\\\t'dark': {\n";
-fileContent += getFileContentFromColorStyle(dark);
-fileContent += '\t\\\t}\n';
-
-fileContent += '\t\\}\n';
-
-// TODO: Extended color palette
-// TODO: Helper vimscript functions
-// IDEA: Maybe these could be added into another file that's either separate or simply added to the end of this one
+fileContent += fs.readFileSync('./ayu.extended.vim');
 
 fs.writeFileSync('./ayu.vim', fileContent);
 
@@ -33,15 +30,17 @@ function getFileContentFromColorStyle(colorStyle) {
         for (let color in colorStyle[group]) {
             if (isClass(colorStyle[group][color])) { // Is a "Color" class
                 const hex = colorStyle[group][color].hex('blend');
-                ret += `\t\\\t\t'${group}_${color}': '${hex}',\n`;
+                ret += `    \\        '${group}_${color}': '${hex}',\n`;
             } else {
                 for (let state in colorStyle[group][color]) {
                     const hex = colorStyle[group][color][state].hex('blend');
-                    ret += `\t\\\t\t'${group}_${state}_${color}': '${hex}',\n`;
+                    ret += `    \\        '${group}_${state}_${color}': '${hex}',\n`;
                 }
             }
         }
     }
+
+    ret = ret.slice(0, ret.length - 1);
 
     return ret;
 }

--- a/generator/index.js
+++ b/generator/index.js
@@ -23,7 +23,7 @@ for (let group in light) {
 fileContent += '\n';
 fileContent += fs.readFileSync('./ayu.extended.vim');
 
-fs.writeFileSync('./ayu.vim', fileContent);
+fs.writeFileSync('../autoload/ayu.vim', fileContent);
 
 function getColorDict(group, color, state) {
     let lightHex, mirageHex, darkHex;

--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -1,0 +1,68 @@
+{
+  "name": "ayu-vim-generator",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ayu-vim-generator",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ayu": "^8.0.1"
+      }
+    },
+    "node_modules/@types/chroma-js": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
+      "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
+    },
+    "node_modules/ayu": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ayu/-/ayu-8.0.1.tgz",
+      "integrity": "sha512-yuPZ2kZYQoYaPRQ/78F9rXDVx1rVGCJ1neBYithBoSprD6zPdIJdAKizUXG0jtTBu7nTFyAnVFFYuLnCS3cpDw==",
+      "dependencies": {
+        "@types/chroma-js": "^2.0.0",
+        "chroma-js": "^2.1.0",
+        "nonenumerable": "^1.1.1"
+      }
+    },
+    "node_modules/chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
+    },
+    "node_modules/nonenumerable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nonenumerable/-/nonenumerable-1.1.1.tgz",
+      "integrity": "sha512-ptUD9w9D8WqW6fuJJkZNCImkf+0vdbgUTbRK3i7jsy3olqtH96hYE6Q/S3Tx9NWbcB/ocAjYshXCAUP0lZ9B4Q=="
+    }
+  },
+  "dependencies": {
+    "@types/chroma-js": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
+      "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
+    },
+    "ayu": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ayu/-/ayu-8.0.1.tgz",
+      "integrity": "sha512-yuPZ2kZYQoYaPRQ/78F9rXDVx1rVGCJ1neBYithBoSprD6zPdIJdAKizUXG0jtTBu7nTFyAnVFFYuLnCS3cpDw==",
+      "requires": {
+        "@types/chroma-js": "^2.0.0",
+        "chroma-js": "^2.1.0",
+        "nonenumerable": "^1.1.1"
+      }
+    },
+    "chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
+    },
+    "nonenumerable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nonenumerable/-/nonenumerable-1.1.1.tgz",
+      "integrity": "sha512-ptUD9w9D8WqW6fuJJkZNCImkf+0vdbgUTbRK3i7jsy3olqtH96hYE6Q/S3Tx9NWbcB/ocAjYshXCAUP0lZ9B4Q=="
+    }
+  }
+}

--- a/generator/package.json
+++ b/generator/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ayu-vim-generator",
+  "version": "0.1.0",
+  "description": "Generate ayu.vim file from the ayu package",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "exec": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Luxed/ayu-vim.git"
+  },
+  "keywords": [
+    "ayu",
+    "ayu-vim",
+    "theme",
+    "colorscheme",
+    "vim",
+    "neovim"
+  ],
+  "author": "Corentin Brunel",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Luxed/ayu-vim/issues"
+  },
+  "homepage": "https://github.com/Luxed/ayu-vim#readme",
+  "dependencies": {
+    "ayu": "^8.0.1"
+  }
+}

--- a/generator/package.json
+++ b/generator/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "exec": "node index.js",
+    "gen": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
This allows us to always be up to date with `ayu-colors` without having to manually change the data each time.

With this update comes a few more additions and changes like:
- darker overall `mirage` theme. Especially the following: folds, Pmenu and floating windows.
- Better integration with `nvim-cmp`
- lighter, less intrusive Search (using the theme's search highlights)